### PR TITLE
Replace `navigator.language` with  `navigator.languages[0]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 coverage
 node_modules
+*.iml

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "oak-i18n-behavior",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/oak-i18n-behavior.html
+++ b/oak-i18n-behavior.html
@@ -11,7 +11,7 @@
     };
     var computeLocale = function(lang) {
       var regex = /^\w{2}/;
-      lang = (typeof lang !== 'string' || !lang) ? navigator.language : lang;
+      lang = (typeof lang !== 'string' || !lang) ? navigator.languages[0] : lang;
       var matches = lang.match(regex);
 
       if (matches && matches.length) {
@@ -23,9 +23,9 @@
     // By default we use the ISO 639-1 standard for language
     // codes (https://www.loc.gov/standards/iso639-2/php/code_list.php).
     // Set the default value of `_locale` to a trimmed 2 character version
-    // of the value of `navigator.language` if `fslanguage` is not present
+    // of the value of `navigator.languages[0]` if `fslanguage` is not present
     var _locale = (function(fslanguage) {
-      return fslanguage || computeLocale(navigator.language);          
+      return fslanguage || computeLocale(navigator.languages[0]);
     })(readCookie('fslanguage'));
 
     var _instances = [];

--- a/test/basic-test.html
+++ b/test/basic-test.html
@@ -39,7 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('it should properly set the lang', function() {
-          expect(navigator.language).to.contain(el.lang);
+          expect(navigator.languages[0]).to.contain(el.lang);
         });
 
       });


### PR DESCRIPTION
### Changes
This is a Chrome only issue.

- Changed to use `navigator.languages[0]` to get the browser language instead of `navigator.language` because Chrome sets `navigator.language` to the OS language instead of the preferred language set by the user in the browser.