### PR TITLE
Upgrade to hybrid polymer 1 and 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components
 coverage
 node_modules
 *.iml
+analysis.json

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "oak-i18n-behavior",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],
@@ -18,10 +18,10 @@
     "/test/"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.2.0"
+    "polymer": "Polymer/polymer#1.9 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "web-component-tester": "^4.0.0"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 3",
+    "web-component-tester": "5 - 6"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>oak-i18n-behavior Demo</title>
-    <script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="../oak-i18n-behavior.html">
   </head>
   <body>
@@ -24,8 +24,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </p>
 
     <script>
-      var lang = document.querySelector('#lang');
-      lang.textContent = OakI18nBehavior.locale;
+      document.addEventListener('WebComponentsReady', function(){
+        var lang = document.querySelector('#lang');
+        lang.textContent = OakI18nBehavior.locale;
+      });
+
     </script>
 
   </body>


### PR DESCRIPTION
This is so that you can include it in a polymer 1.x or 2.x app without having to add a resolution. It also makes sure that it runs ok in polymer 2.